### PR TITLE
Improv dockerfile

### DIFF
--- a/alpine-javabase/Dockerfile
+++ b/alpine-javabase/Dockerfile
@@ -1,15 +1,11 @@
 FROM oberthur/docker-alpine-java
 
-RUN apk add --update git wget
+ENV M2_HOME=/usr/lib/mvn M2=$M2_HOME/bin PATH=$PATH:$M2_HOME:$M2
 
-RUN wget http://ftp.fau.de/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-RUN tar -zxvf apache-maven-3.3.9-bin.tar.gz
-RUN rm apache-maven-3.3.9-bin.tar.gz
-RUN mv apache-maven-3.3.9 /usr/lib/mvn
+RUN apk add --update wget \
+ && wget http://ftp.fau.de/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz \
+ && tar -zxvf apache-maven-3.3.9-bin.tar.gz \
+ && rm apache-maven-3.3.9-bin.tar.gz \
+ && mv apache-maven-3.3.9 /usr/lib/mvn \
+ && apk del wget && rm /var/cache/apk/*
 
-RUN apk del wget && \
-	rm /var/cache/apk/*
-
-ENV M2_HOME=/usr/lib/mvn
-ENV M2=$M2_HOME/bin
-ENV PATH $PATH:$M2_HOME:$M2

--- a/alpine-javabase/Dockerfile
+++ b/alpine-javabase/Dockerfile
@@ -1,6 +1,6 @@
 FROM oberthur/docker-alpine-java
 
-ENV M2_HOME=/usr/lib/mvn M2=$M2_HOME/bin PATH=$PATH:$M2_HOME:$M2
+ENV M2_HOME=/usr/lib/mvn M2=/usr/lib/mvn/bin PATH=$PATH:/usr/lib/mvn:/usr/lib/mvn/bin
 
 RUN apk add --update wget \
  && wget http://ftp.fau.de/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz \


### PR DESCRIPTION
- remove git - not used
- reduced layers (from 9 to 2)
- merged install/delete into single step to save on space (when you do
  it in seperate layers it doesn't actually save space as the previous
  layer still contains the data

Original: 220.3 MB
New:      185.6 MB
